### PR TITLE
ICICLE v1.9 with correctness

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/google/pprof v0.0.0-20230817174616-7a8ec2ada47b
 	github.com/icza/bitio v1.1.0
+	github.com/ingonyama-zk/icicle v1.9.1
 	github.com/ingonyama-zk/iciclegnark v0.1.2-0.20240329204201-5a05ea507886
 	github.com/leanovate/gopter v0.2.9
 	github.com/rs/zerolog v1.30.0
@@ -23,7 +24,6 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/ingonyama-zk/icicle v1.9.1 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect
 	github.com/mmcloughlin/addchain v0.4.0 // indirect

--- a/testgpu/gpu_test.go
+++ b/testgpu/gpu_test.go
@@ -1,6 +1,10 @@
 package testgpu
 
 import (
+	"math/big"
+	"os"
+	"testing"
+
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/backend"
 	"github.com/consensys/gnark/backend/groth16"
@@ -12,9 +16,6 @@ import (
 	regroth16 "github.com/consensys/gnark/std/recursion/groth16"
 	"github.com/consensys/gnark/test"
 	"github.com/rs/zerolog"
-	"math/big"
-	"os"
-	"testing"
 )
 
 func TestBn254Gpu(t *testing.T) {


### PR DESCRIPTION
# Description

This PR achieves correctness with fully on-device prover based on icicle v1.9.
Tested by running `TestBn254Gpu` (don't forget to enable `g2` tag). Hopefully the performance is ok but I haven't tested on circuits of significant size, so actually not sure if they work and how fast. One detail to note: `InitDomain` is only called once per curve, so when setting up several circuits, it's best to run the setup for the largest circuit first, this way you'll ensure that `InitDomain` covers all the circuits. If that's not possible, we'll make a slight change.

In general, the PR is a bit messy - no proper error handling, only bn254 supported etc., but hopefully it's clear how to proceed from here.